### PR TITLE
ci: Add GitHub Actions for testing build and deployment to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron:  '1 0 * * 0'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Docker image
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List Built Images
+      run: docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # [skopeo](https://github.com/containers/skopeo) Docker image
 
 Docker image built [`FROM golang:latest`](https://hub.docker.com/_/golang) with `skopeo` [installed from source](https://github.com/containers/skopeo#building-without-a-container)
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/matthewfeickert/skopeo-docker)](https://hub.docker.com/r/matthewfeickert/skopeo-docker)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/matthewfeickert/skopeo-docker/latest)](https://hub.docker.com/r/matthewfeickert/skopeo-docker/tags?name=latest)


### PR DESCRIPTION
Use the [official Docker GitHub Action](https://github.com/docker/build-push-action) to test and publish the Docker image to Docker Hub.

Using the `tag_with_ref` option, tag the image with the version release number and `latest-stable` when the push is a tag release.

Additionally add Docker Hub information badges to README

```
* Add CI to test build and to deploy to Docker Hub
* Add Docker Hub badges to README
```