### PR TITLE
feat: Use multistage builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build Docker image
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN useradd -m docker && \
     chown -R --from=root docker /home/docker
 
 COPY --from=builder $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/local/bin/
+COPY --from=builder $GOPATH/src/github.com/containers/skopeo/default-policy.json /etc/containers/policy.json
 
 WORKDIR /home/docker
 ENV HOME /home/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 
-RUN git clone --depth 1 https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
+ARG VERSION_TAG=v1.1.0
+RUN git clone --depth 1 https://github.com/containers/skopeo \
+      --branch "${VERSION_TAG}" \
+      --single-branch \
+      $GOPATH/src/github.com/containers/skopeo && \
     cd $GOPATH/src/github.com/containers/skopeo && \
     make bin/skopeo && \
     mkdir -p /etc/containers && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN git clone --depth 1 https://github.com/containers/skopeo \
       --single-branch \
       $GOPATH/src/github.com/containers/skopeo && \
     cd $GOPATH/src/github.com/containers/skopeo && \
-    make bin/skopeo && \
+    make binary-local && \
     mkdir -p /etc/containers && \
     cp default-policy.json /etc/containers/policy.json && \
-    ./bin/skopeo --help
+    ./skopeo --help
 
 FROM base
 RUN apt-get -qq -y update && \
@@ -46,7 +46,7 @@ RUN useradd -m docker && \
     cp /root/.bashrc /home/docker/ && \
     chown -R --from=root docker /home/docker
 
-COPY --from=builder $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/local/bin/
+COPY --from=builder $GOPATH/src/github.com/containers/skopeo/skopeo /usr/local/bin/
 COPY --from=builder $GOPATH/src/github.com/containers/skopeo/default-policy.json /etc/containers/policy.json
 
 WORKDIR /home/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get -qq -y update && \
         libgpgme-dev \
         libassuan-dev \
         libbtrfs-dev \
-        libdevmapper-dev && \
+        libdevmapper-dev \
+        sudo && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:latest
+ARG BASE_IMAGE=golang:latest
+FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash", "-c" ]
 
-# https://github.com/containers/skopeo#building-without-a-container
+FROM base as builder
+# https://github.com/containers/skopeo/blob/master/install.md#building-without-a-container
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     apt-get -qq -y install \
         libgpgme-dev \
         libassuan-dev \
@@ -18,11 +19,21 @@ RUN apt-get -qq -y update && \
 
 RUN git clone --depth 1 https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
     cd $GOPATH/src/github.com/containers/skopeo && \
-    make binary-local && \
+    make bin/skopeo && \
     mkdir -p /etc/containers && \
     cp default-policy.json /etc/containers/policy.json && \
-    ./skopeo --help
+    ./bin/skopeo --help
 
+FROM base
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install \
+        libgpgme-dev \
+        libassuan-dev \
+        libbtrfs-dev \
+        libdevmapper-dev && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt-get/lists/*
 # Create user "docker" with sudo powers
 RUN useradd -m docker && \
     usermod -aG sudo docker && \
@@ -30,12 +41,11 @@ RUN useradd -m docker && \
     cp /root/.bashrc /home/docker/ && \
     chown -R --from=root docker /home/docker
 
-RUN mv $GOPATH/src/github.com/containers/skopeo/skopeo /home/docker/skopeo
+COPY --from=builder $GOPATH/src/github.com/containers/skopeo/bin/skopeo /usr/local/bin/
 
 WORKDIR /home/docker
 ENV HOME /home/docker
 ENV USER docker
 USER docker
-ENV PATH /home/docker/.local/bin:$PATH
 
 CMD [ "/bin/bash" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default: image
+
+all: image
+
+image:
+	docker build . \
+	-f Dockerfile \
+	--tag matthewfeickert/skopeo-docker:debug-latest
+
+run:
+	docker run --rm -it matthewfeickert/skopeo-docker:debug-latest

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
+	--build-arg VERSION_TAG=v1.1.0 \
 	--tag matthewfeickert/skopeo-docker:debug-latest
 
 run:


### PR DESCRIPTION
Use multistage builds to decrease final image size and fix build issue that came with API change in [`skopeo` `v1.1.1`](https://github.com/containers/skopeo/releases/tag/v1.1.1). This change renames the `binary-local` `Make` target to `bin/skopeo`, changing paths. To avoid breaks like this, a version tag build argument is introduced to only build stable tags.

Additionally, add `Makefile`.