### PR TITLE
ci: Add GitHub Packages as image registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,16 @@ jobs:
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest
+    - name: Publish to GitHub Packages
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        repository: matthewfeickert/skopeo-docker/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -30,6 +40,17 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true
+    - name: Publish to GitHub Packages with Release Tag
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        repository: matthewfeickert/skopeo-docker/skopeo-docker
         dockerfile: Dockerfile
         tags: latest,latest-stable
         tag_with_ref: true


### PR DESCRIPTION
Add [GitHub Packages](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages) as an image registry using the Docker `build-and-push` action. Thanks to @roderik for [pointing out that GHA will cache the image from the previous build](https://twitter.com/r0derik/status/1278035296240705542), so I don't have to manually control this.

```
* Add GitHub Packages as image registry
   - c.f. https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
```