### PR TITLE
feat: Migrate to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - v*
+    # branches:
+    # - master
+    # tags:
+    # - v*
 
 jobs:
   build-and-publish:
@@ -14,15 +14,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build and Publish to Registry
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/skopeo-docker
-        dockerfile: Dockerfile
-        tags: latest
+    # - name: Build and Publish to Registry
+    #   if: "!(startsWith(github.ref, 'refs/tags/'))"
+    #   uses: docker/build-push-action@v1
+    #   with:
+    #     username: ${{ secrets.DOCKER_USERNAME }}
+    #     password: ${{ secrets.DOCKER_PASSWORD }}
+    #     repository: matthewfeickert/skopeo-docker
+    #     dockerfile: Dockerfile
+    #     tags: latest
     - name: Publish to GitHub Packages
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
@@ -33,16 +33,16 @@ jobs:
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest
-    - name: Build and Publish to Registry with Release Tag
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/skopeo-docker
-        dockerfile: Dockerfile
-        tags: latest,latest-stable
-        tag_with_ref: true
+    # - name: Build and Publish to Registry with Release Tag
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   uses: docker/build-push-action@v1
+    #   with:
+    #     username: ${{ secrets.DOCKER_USERNAME }}
+    #     password: ${{ secrets.DOCKER_PASSWORD }}
+    #     repository: matthewfeickert/skopeo-docker
+    #     dockerfile: Dockerfile
+    #     tags: latest,latest-stable
+    #     tag_with_ref: true
     - name: Publish to GitHub Packages with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,8 @@ jobs:
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
-        repository: matthewfeickert/skopeo-docker/skopeo-docker
+        registry: ghcr.io
+        repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest
     - name: Build and Publish to Registry with Release Tag
@@ -49,8 +49,8 @@ jobs:
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
-        repository: matthewfeickert/skopeo-docker/skopeo-docker
+        registry: ghcr.io
+        repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest,latest-stable
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
 
 jobs:
   build-and-publish:
@@ -14,15 +14,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # - name: Build and Publish to Registry
-    #   if: "!(startsWith(github.ref, 'refs/tags/'))"
-    #   uses: docker/build-push-action@v1
-    #   with:
-    #     username: ${{ secrets.DOCKER_USERNAME }}
-    #     password: ${{ secrets.DOCKER_PASSWORD }}
-    #     repository: matthewfeickert/skopeo-docker
-    #     dockerfile: Dockerfile
-    #     tags: latest
+    - name: Build and Publish to Registry
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest
     - name: Publish to GitHub Packages
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
@@ -33,16 +33,16 @@ jobs:
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest
-    # - name: Build and Publish to Registry with Release Tag
-    #   if: startsWith(github.ref, 'refs/tags/')
-    #   uses: docker/build-push-action@v1
-    #   with:
-    #     username: ${{ secrets.DOCKER_USERNAME }}
-    #     password: ${{ secrets.DOCKER_PASSWORD }}
-    #     repository: matthewfeickert/skopeo-docker
-    #     dockerfile: Dockerfile
-    #     tags: latest,latest-stable
-    #     tag_with_ref: true
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matthewfeickert/skopeo-docker
+        dockerfile: Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true
     - name: Publish to GitHub Packages with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
         tags: latest
-    - name: Publish to GitHub Packages
+    - name: Publish to GitHub Container Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
@@ -43,7 +43,7 @@ jobs:
         dockerfile: Dockerfile
         tags: latest,latest-stable
         tag_with_ref: true
-    - name: Publish to GitHub Packages with Release Tag
+    - name: Publish to GitHub Container Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
         registry: ghcr.io
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile
@@ -48,7 +48,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
         registry: ghcr.io
         repository: matthewfeickert/skopeo-docker
         dockerfile: Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_TOKEN }}
         registry: ghcr.io
         repository: matthewfeickert/skopeo-docker
@@ -47,7 +47,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
       with:
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_TOKEN }}
         registry: ghcr.io
         repository: matthewfeickert/skopeo-docker


### PR DESCRIPTION
Migrate from the [GitHub Packages](https://github.com/matthewfeickert/skopeo-docker/packages/293459) to the [GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/) with a personal access token.

```
* Migrate from the GitHub Packages to the GitHub Container Registry
   - Uses a personal access token
   - c.f. https://www.docker.com/blog/docker-support-for-the-new-github-container-registry/
```